### PR TITLE
make use of the new progress bar monitor in interactive mode, while remaining with the logger MojoRascalMonitor in batch mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.rascalmpl</groupId>
             <artifactId>rascal</artifactId>
-            <version>0.36.1-RC2</version>
+            <version>0.38.1-BOOT1</version>
         </dependency>
         <dependency>
             <groupId>org.rascalmpl</groupId>

--- a/src/main/java/org/rascalmpl/maven/CompileRascalDocumentation.java
+++ b/src/main/java/org/rascalmpl/maven/CompileRascalDocumentation.java
@@ -17,6 +17,7 @@ import java.net.URISyntaxException;
 import java.util.LinkedList;
 import java.util.List;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -115,11 +116,11 @@ public class CompileRascalDocumentation extends AbstractMojo
 	@Parameter(property="sources", required=false)
 	private String sources;
 
-
-	private final MojoRascalMonitor monitor = new MojoRascalMonitor(getLog(), false);
+	@Parameter(defaultValue = "${session}", required = true, readonly = true)
+	private MavenSession session;
 
 	private Evaluator makeEvaluator(OutputStream err, OutputStream out) throws URISyntaxException, FactTypeUseException, IOException {
-		return MojoUtils.makeEvaluator(getLog(), monitor,err, out, MAIN_COMPILER_SEARCH_PATH, MAIN_COMPILER_MODULE);
+		return MojoUtils.makeEvaluator(getLog(), session, err, out, MAIN_COMPILER_SEARCH_PATH, MAIN_COMPILER_MODULE);
 	}
 
 	public void execute() throws MojoExecutionException {
@@ -166,7 +167,8 @@ public class CompileRascalDocumentation extends AbstractMojo
 					)
 				);
 
-			IList messages = runCompiler(monitor, makeEvaluator(System.err, System.out), pcfg);
+			Evaluator eval = makeEvaluator(System.err, System.out);
+			IList messages = runCompiler(eval.getMonitor(), eval, pcfg);
 
 			getLog().info("Tutor is done, reporting errors now.");
 			handleMessages(pcfg, messages);

--- a/src/main/java/org/rascalmpl/maven/MojoRascalMonitor.java
+++ b/src/main/java/org/rascalmpl/maven/MojoRascalMonitor.java
@@ -5,6 +5,9 @@ import org.rascalmpl.debug.IRascalMonitor;
 
 import io.usethesource.vallang.ISourceLocation;
 
+/**
+ * This monitor is for batch mode. We can use the TerminalProgressBarMonitor for interactive mode.
+ */
 public class MojoRascalMonitor implements IRascalMonitor {
 	private final Log log;
     private final boolean chatty;
@@ -48,5 +51,10 @@ public class MojoRascalMonitor implements IRascalMonitor {
 		synchronized (log) {
 			log.warn(src.toString() + ": " + message);
 		}
+	}
+
+	@Override
+	public void endAllJobs() {
+		// Do nothing
 	}
 }

--- a/src/main/java/org/rascalmpl/maven/MojoUtils.java
+++ b/src/main/java/org/rascalmpl/maven/MojoUtils.java
@@ -57,7 +57,7 @@ public class MojoUtils {
 		GlobalEnvironment heap = new GlobalEnvironment();
 
 		IRascalMonitor monitor = session.getRequest().isInteractiveMode() 
-			? new TerminalProgressBarMonitor(out, TerminalFactory.get().wrapInIfNeeded(System.in), TerminalFactory.get()) 
+			? getTerminalProgressBarInstance() 
 			: new MojoRascalMonitor(log, false);
 
 		Evaluator eval = new Evaluator(ValueFactoryFactory.getValueFactory(), new ByteArrayInputStream(new byte[0]), err, out, monitor, new ModuleEnvironment("***MVN Rascal Compiler***", heap), heap);
@@ -81,6 +81,14 @@ public class MojoUtils {
 		safeLog(log, l -> l.info("Done loading the compiler."));
 
 		return eval;
+	}
+
+	private static class MonitorInstanceHolder {
+		static IRascalMonitor monitor = new TerminalProgressBarMonitor(System.out, System.in, TerminalFactory.get());
+	}
+
+	private static IRascalMonitor getTerminalProgressBarInstance() {
+		return MonitorInstanceHolder.monitor;
 	}
 
 	private static String toClassPath(Class<?>... clazz) {

--- a/src/main/java/org/rascalmpl/maven/MojoUtils.java
+++ b/src/main/java/org/rascalmpl/maven/MojoUtils.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.rascalmpl.uri.URIResolverRegistry;
@@ -29,12 +30,14 @@ import org.rascalmpl.interpreter.Evaluator;
 import org.rascalmpl.interpreter.env.GlobalEnvironment;
 import org.rascalmpl.interpreter.env.ModuleEnvironment;
 import org.rascalmpl.interpreter.utils.RascalManifest;
+import org.rascalmpl.repl.TerminalProgressBarMonitor;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.values.ValueFactoryFactory;
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IValueFactory;
 import io.usethesource.vallang.exceptions.FactTypeUseException;
 import io.usethesource.vallang.io.StandardTextReader;
+import jline.TerminalFactory;
 
 public class MojoUtils {
 
@@ -49,10 +52,15 @@ public class MojoUtils {
 		eval.addRascalSearchPath(loc);
 	}
 
-	static Evaluator makeEvaluator(Log log, IRascalMonitor monitor, OutputStream err, OutputStream out, ISourceLocation[] searchPath,  String... importedModules) throws URISyntaxException, FactTypeUseException, IOException {
+	static Evaluator makeEvaluator(Log log, MavenSession session, OutputStream err, OutputStream out, ISourceLocation[] searchPath,  String... importedModules) throws URISyntaxException, FactTypeUseException, IOException {
 		safeLog(log, l -> l.info("Start loading the compiler..."));
 		GlobalEnvironment heap = new GlobalEnvironment();
-		Evaluator eval = new Evaluator(ValueFactoryFactory.getValueFactory(), new ByteArrayInputStream(new byte[0]), err, out, new ModuleEnvironment("***MVN Rascal Compiler***", heap), heap);
+
+		IRascalMonitor monitor = session.getRequest().isInteractiveMode() 
+			? new TerminalProgressBarMonitor(out, TerminalFactory.get().wrapInIfNeeded(System.in), TerminalFactory.get()) 
+			: new MojoRascalMonitor(log, false);
+
+		Evaluator eval = new Evaluator(ValueFactoryFactory.getValueFactory(), new ByteArrayInputStream(new byte[0]), err, out, monitor, new ModuleEnvironment("***MVN Rascal Compiler***", heap), heap);
 		eval.getConfiguration().setRascalJavaClassPathProperty(toClassPath(
 			ValueFactoryFactory.class, // rascal jar
 			IValueFactory.class // vallang jar

--- a/src/main/java/org/rascalmpl/maven/PackageRascalMojo.java
+++ b/src/main/java/org/rascalmpl/maven/PackageRascalMojo.java
@@ -14,6 +14,8 @@ package org.rascalmpl.maven;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
+
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -58,10 +60,13 @@ public class PackageRascalMojo extends AbstractMojo
 	@Parameter(defaultValue = "|lib://${project.name}/|", property = "sourceLookup", required = true )
     private String sourceLookup;
 
+	@Parameter(defaultValue = "${session}", required = true, readonly = true)
+  	private MavenSession session;
+
 	private Evaluator makeEvaluator() throws URISyntaxException, FactTypeUseException, IOException {
 		return MojoUtils.makeEvaluator(
 			getLog(),
-			new MojoRascalMonitor(getLog(), false),
+			session,
 			System.err, System.out,
 			MAIN_PACKAGER_SEARCH_PATH,
 			MAIN_PACKAGER_MODULE


### PR DESCRIPTION
* This uses the Session object to ask maven whether or not we are in interactive mode. That's nice.
* Storing the monitor as a singleton helps to make sure everything starts up nicely between the parallel checker threads. 
