### PR TITLE
Fixed bug that would hide the failure of the nested jvm

### DIFF
--- a/src/main/java/org/rascalmpl/maven/GenerateSourcesUsingRascalMojo.java
+++ b/src/main/java/org/rascalmpl/maven/GenerateSourcesUsingRascalMojo.java
@@ -59,11 +59,14 @@ public class GenerateSourcesUsingRascalMojo extends AbstractMojo
             ProcessBuilder builder = new ProcessBuilder(command);
             builder.directory(project.getBasedir());
             Process process = builder.inheritIO().start();
-            process.waitFor();
-        } 
+            int result = process.waitFor();
+            if (result != 0) {
+                throw new MojoExecutionException("Generate sources failed to complete");
+            }
+        }
         catch (IOException e) {
             getLog().error(e);
-        } 
+        }
         catch (InterruptedException e) {
             getLog().warn(e);
         }


### PR DESCRIPTION
This should avoid maven ignoring a failure in the generate-sources phase