### PR TITLE
Fixed code generation phase for multi-module maven projects

### DIFF
--- a/src/main/java/org/rascalmpl/maven/GenerateSourcesUsingRascalMojo.java
+++ b/src/main/java/org/rascalmpl/maven/GenerateSourcesUsingRascalMojo.java
@@ -52,7 +52,10 @@ public class GenerateSourcesUsingRascalMojo extends AbstractMojo
         command.add(javaBin);
 
         System.getProperties().forEach((key, value) -> {
-            command.add("-D" + key + "=" + value);
+            // Do not propagate `user.dir`, since that breaks multi-module maven projects
+            if (!key.equals("user.dir")) {
+                command.add("-D" + key + "=" + value);
+            }
         });
         
         command.add("-cp");


### PR DESCRIPTION
The `user.dir` property has the value of the root of a multi-module project. Propagating this value to the spawned processes for the modules ensured that the `RASCAL.MF` file could not be found, eventually crashing the build.