### PR TITLE
add screenshot jar injection to the tutor execution

### DIFF
--- a/src/main/java/org/rascalmpl/maven/AbstractRascalMojo.java
+++ b/src/main/java/org/rascalmpl/maven/AbstractRascalMojo.java
@@ -85,7 +85,7 @@ public abstract class AbstractRascalMojo extends AbstractMojo
 	@Parameter(defaultValue = "${session}", required = true, readonly = true)
   	private MavenSession session;
 
-	@Parameter(defaultValue = "0.41.0-RC24", required = false, readonly = false)
+	@Parameter(defaultValue = "0.41.0-RC32", required = false, readonly = false)
 	protected String bootstrapRascalVersion;
 
 	@SuppressWarnings("deprecation") // Can't get @Parameter to work for the pluginManager.
@@ -134,6 +134,20 @@ public abstract class AbstractRascalMojo extends AbstractMojo
 		return cachedRascalRuntime;
 	}
 
+	protected String getScreenShotJar() {
+		for (Object o : project.getArtifacts()) {
+			Artifact a = (Artifact) o;
+
+			if (a.getGroupId().equals("org.rascalmpl") && a.getArtifactId().equals("rascal-tutor-screenshot")) {
+				File file = a.getFile().getAbsoluteFile();
+
+				return file.toString();
+			}
+		}
+
+		return "";
+	}
+
 	/**
 	 * Converts a list of files to a string;Of;Paths using the OS's native path separator
 	 */
@@ -176,7 +190,7 @@ public abstract class AbstractRascalMojo extends AbstractMojo
 
 			setExtraParameters();
 
-			runMain(verbose, srcs, srcIgnores, libs, generatedSources, bin, extraParameters, true, 1).waitFor();
+			runMain(verbose, "", srcs, srcIgnores, libs, generatedSources, bin, extraParameters, true, 1).waitFor();
 
 			return;
 		}
@@ -251,7 +265,7 @@ public abstract class AbstractRascalMojo extends AbstractMojo
 	}
 
 	protected final ArtifactVersion getReferenceRascalVersion() {
-		return new DefaultArtifactVersion("0.41.0-RC26");
+		return new DefaultArtifactVersion("0.41.0-RC30");
 	}
 
 	protected Path installBootstrapRascalVersion(MavenProject project, MavenSession session) throws MojoExecutionException {
@@ -278,7 +292,7 @@ public abstract class AbstractRascalMojo extends AbstractMojo
 			"org", "rascalmpl", "rascal", bootstrapRascalVersion, "rascal-" + bootstrapRascalVersion + ".jar");
 	}
 
-	protected Process runMain(boolean verbose, List<File> srcs, List<File> ignores, List<File> libs, File generated, File bin, Map<String, String> extraParameters, boolean inheritIO, int numProcesses) throws IOException {
+	protected Process runMain(boolean verbose, String moreClasspath, List<File> srcs, List<File> ignores, List<File> libs, File generated, File bin, Map<String, String> extraParameters, boolean inheritIO, int numProcesses) throws IOException {
 		String javaHome = System.getProperty("java.home");
         String javaBin = javaHome + File.separator + "bin" + File.separator + "java";
 
@@ -299,7 +313,7 @@ public abstract class AbstractRascalMojo extends AbstractMojo
 		// we put the entire pathConfig on the commandline, and finally the todoList for compilation.
 		command.add("--illegal-access=deny");
 		command.add("-cp");
-		command.add(getRascalRuntime().toString());
+		command.add(getRascalRuntime().toString() + (moreClasspath.isEmpty() ? "" : File.pathSeparator + moreClasspath));
 
 		assert mainClass != null : "mainClass is null";
 

--- a/src/main/java/org/rascalmpl/maven/CompileRascalDocumentation.java
+++ b/src/main/java/org/rascalmpl/maven/CompileRascalDocumentation.java
@@ -103,7 +103,7 @@ public class CompileRascalDocumentation extends AbstractRascalMojo
 				extraParameters.put("packageName", project.getId());
 			}
 
-			runMain(verbose, srcs, srcIgnores, libs, generatedSources, bin, extraParameters, true, 1).waitFor();
+			runMain(verbose, getScreenShotJar(), srcs, srcIgnores, libs, generatedSources, bin, extraParameters, true, 1).waitFor();
 
 			return;
 		}

--- a/src/main/java/org/rascalmpl/maven/CompileRascalMojo.java
+++ b/src/main/java/org/rascalmpl/maven/CompileRascalMojo.java
@@ -221,7 +221,7 @@ public class CompileRascalMojo extends AbstractRascalMojo
 			if (!todoChunk.isEmpty()) {
 				setExtraCompilerParameters(verbose, todoChunk, extraParameters);
 				getLog().info("Pre-compiling common modules " + prechecks.stream().map(f -> f.getName()).collect(Collectors.joining(", ")));
-				Process prechecker = runMain(verbose, srcs, srcIgnores, libs, tmpGeneratedSources.get(0), tmpBins.get(0), extraParameters, true, 1);
+				Process prechecker = runMain(verbose, "", srcs, srcIgnores, libs, tmpGeneratedSources.get(0), tmpBins.get(0), extraParameters, true, 1);
 
 				var exitCode = prechecker.waitFor();
 				getLog().info("Pre-compilation finished (" + exitCode + ")");
@@ -241,7 +241,7 @@ public class CompileRascalMojo extends AbstractRascalMojo
 				if (!chunk.isEmpty()) { // can become empty by removing the pre-checks.
 					setExtraCompilerParameters(verbose, chunks.get(i), extraParameters);
 					getLog().info("Compiler " + i + " started on a parallel job of " + chunks.get(i).size() + " modules.");
-					processes.add(runMain(verbose, srcs, srcIgnores, libs, tmpGeneratedSources.get(i), tmpBins.get(i), extraParameters, i <= 1, chunks.size()));
+					processes.add(runMain(verbose, "", srcs, srcIgnores, libs, tmpGeneratedSources.get(i), tmpBins.get(i), extraParameters, i <= 1, chunks.size()));
 				}
 			}
 
@@ -306,7 +306,7 @@ public class CompileRascalMojo extends AbstractRascalMojo
 		getLog().info("Running single checker process");
 		try {
 			setExtraCompilerParameters(verbose, todoList, extraParameters);
-			return runMain(verbose, srcLocs, srcIgnores, libLocs, generated, binLoc, extraParameters, true, 1).waitFor();
+			return runMain(verbose, "",srcLocs, srcIgnores, libLocs, generated, binLoc, extraParameters, true, 1).waitFor();
 		} catch (InterruptedException e) {
 			getLog().error("Checker was interrupted");
 			throw new MojoExecutionException(e);


### PR DESCRIPTION
This is to reintegrate the screenshot functionality that was extracted into a separate project earlier. All this does is adding he new jar to the JVM process' classpath for the tutor. The tutor should detect the new class that implements `IScreenshot` automatically from there. 