### PR TITLE
if the current project is rascal, then the tutor uses the classes in target/classes to run library code against

### DIFF
--- a/src/main/java/org/rascalmpl/maven/AbstractRascalMojo.java
+++ b/src/main/java/org/rascalmpl/maven/AbstractRascalMojo.java
@@ -135,6 +135,10 @@ public abstract class AbstractRascalMojo extends AbstractMojo
 		return cachedRascalRuntime;
 	}
 
+	protected boolean isRascalProject() {
+		return project.getGroupId().equals("org.rascalmpl") && project.getId().equals("rascal");
+	}
+
 	/**
 	 * Converts a list of files to a string;Of;Paths using the OS's native path separator
 	 */

--- a/src/main/java/org/rascalmpl/maven/AbstractRascalMojo.java
+++ b/src/main/java/org/rascalmpl/maven/AbstractRascalMojo.java
@@ -136,7 +136,7 @@ public abstract class AbstractRascalMojo extends AbstractMojo
 	}
 
 	protected boolean isRascalProject() {
-		return project.getGroupId().equals("org.rascalmpl") && project.getId().equals("rascal");
+		return project.getGroupId().equals("org.rascalmpl") && project.getArtifactId().equals("rascal");
 	}
 
 	/**

--- a/src/main/java/org/rascalmpl/maven/TutorRascalMojo.java
+++ b/src/main/java/org/rascalmpl/maven/TutorRascalMojo.java
@@ -22,6 +22,7 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -78,6 +79,18 @@ public class TutorRascalMojo extends AbstractRascalMojo
 		super("org.rascalmpl.shell.RascalTutorCompile", "tutor");
 	}
 
+	/**
+	 * Enables tutor bootstrap
+	 */
+	protected Path getRascalRuntime() {
+		if (isRascalProject()) {
+			// bootstrap mode
+			return bin.toPath();
+		}
+
+		return super.getRascalRuntime();
+	}
+
 	@Override
 	public void execute() throws MojoExecutionException {
 		try {
@@ -95,7 +108,8 @@ public class TutorRascalMojo extends AbstractRascalMojo
 				getLog().warn("\tignoring sources in: " + ignore);
 			}
 
-			libs.addAll(collectDependentArtifactLibraries(project));
+			var deps = collectDependentArtifactLibraries(project);
+			libs.addAll(deps);
 
 			for (File lib : libs) {
 				getLog().info("\tregistered library location: " + lib);
@@ -128,7 +142,7 @@ public class TutorRascalMojo extends AbstractRascalMojo
 
 			int exitCode = runMain(
 				verbose,
-				screenshotter,
+				screenshotter + (isRascalProject() ? (File.pathSeparator + deps.stream().map(Object::toString).collect(Collectors.joining(File.pathSeparator))) : ""),
 				srcs,
 				srcIgnores,
 				libs,

--- a/src/main/java/org/rascalmpl/maven/TutorRascalMojo.java
+++ b/src/main/java/org/rascalmpl/maven/TutorRascalMojo.java
@@ -140,6 +140,8 @@ public class TutorRascalMojo extends AbstractRascalMojo
 				screenshotter = "";
 			}
 
+			deps.add(0, bin);
+
 			int exitCode = runMain(
 				verbose,
 				screenshotter + (isRascalProject() ? (File.pathSeparator + deps.stream().map(Object::toString).collect(Collectors.joining(File.pathSeparator))) : ""),


### PR DESCRIPTION
Make sure that if the tutor is used on the rascal standard library, the library loads the newest versions of the classes and not the older ones from the bootstrap.